### PR TITLE
fix: logger -> dlogger

### DIFF
--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -97,8 +97,8 @@ int main(int argc, char *argv[])
         rollingFileAppender->setLogFilesLimit(5);
         rollingFileAppender->setDatePattern(RollingFileAppender::DailyRollover);
 
-        logger->registerAppender(rollingFileAppender);
-        logger->registerAppender(consoleAppender);
+        dlogger->registerAppender(rollingFileAppender);
+        dlogger->registerAppender(consoleAppender);
 
         if (qEnvironmentVariableIsSet("PKEXEC_UID")) {
             const quint32 pkexec_uid = qgetenv("PKEXEC_UID").toUInt();
@@ -176,8 +176,8 @@ int main(int argc, char *argv[])
     rollingFileAppender->setLogFilesLimit(5);
     rollingFileAppender->setDatePattern(RollingFileAppender::DailyRollover);
 
-    logger->registerCategoryAppender("deepin.ghost", consoleAppender);
-    logger->registerCategoryAppender("deepin.ghost", rollingFileAppender);
+    dlogger->registerCategoryAppender("deepin.ghost", consoleAppender);
+    dlogger->registerCategoryAppender("deepin.ghost", rollingFileAppender);
 #endif
 
     parser.parse();


### PR DESCRIPTION
Recent version of dtkcore changed `logger`'s name to `dlogger`: https://github.com/linuxdeepin/dtkcore/commit/24a29a0f9f60a393e0b34f8b2b5d0ec9ea5bdcd1